### PR TITLE
Pin MacOS launchers CI job to `macos-13`

### DIFF
--- a/.github/workflows/launchers.yml
+++ b/.github/workflows/launchers.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-13]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The CI broke, as `macos-latest` now points to `macos-14`, which is `aarch64`.