### PR TITLE
Update artifact actions to v4

### DIFF
--- a/.github/workflows/launchers.yml
+++ b/.github/workflows/launchers.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-13]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -47,7 +47,7 @@ jobs:
   generate-static-launcher:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -73,7 +73,7 @@ jobs:
   generate-mostly-static-launcher:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/launchers.yml
+++ b/.github/workflows/launchers.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: coursier/cache-action@v6.3
+      - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1
         with:
           jvm: 8
@@ -51,7 +51,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: coursier/cache-action@v6.3
+      - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1
         with:
           jvm: 8
@@ -77,7 +77,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: coursier/cache-action@v6.3
+      - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1
         with:
           jvm: 8

--- a/.github/workflows/launchers.yml
+++ b/.github/workflows/launchers.yml
@@ -33,7 +33,7 @@ jobs:
           @call ./mill.bat -i "native.copyToArtifacts" artifacts/
         shell: cmd
         if: runner.os == 'Windows'
-      - uses: actions/upload-artifact@v2.2.4
+      - uses: actions/upload-artifact@v4
         with:
           name: launcher-${{ matrix.os }}
           path: artifacts/
@@ -59,7 +59,7 @@ jobs:
           ./mill -i "native-static.writeNativeImageScript" generate.sh "" && \
           ./generate.sh && \
           ./mill -i "native-static.copyToArtifacts" artifacts/
-      - uses: actions/upload-artifact@v2.2.4
+      - uses: actions/upload-artifact@v4
         with:
           name: launcher-${{ matrix.os }}-static
           path: artifacts/
@@ -85,7 +85,7 @@ jobs:
           ./mill -i "native-mostly-static.writeNativeImageScript" generate.sh "" && \
           ./generate.sh && \
           ./mill -i "native-mostly-static.copyToArtifacts" artifacts/
-      - uses: actions/upload-artifact@v2.2.4
+      - uses: actions/upload-artifact@v4
         with:
           name: launcher-${{ matrix.os }}-mostly-static
           path: artifacts/


### PR DESCRIPTION
v2 artifact actions are no longer supported, so we need to update urgently to fix the CI.
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Included updates:
- `actions/upload-artifact` from v2.2.4 to v4
- `actions/checkout` from v2 to v4
- `coursier/cache-action` from v6.3 to v6.4