### PR TITLE
Bump `scalafmt` to 3.9.7

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -9,7 +9,7 @@ import mill._
 import mill.scalalib._
 
 object Versions {
-  def scalafmtVersion = "3.9.6"
+  def scalafmtVersion = "3.9.7"
 
   def scalaVersion = "2.13.16"
 


### PR DESCRIPTION
https://github.com/scalameta/scalafmt/releases/tag/v3.9.7